### PR TITLE
Remove company dependency

### DIFF
--- a/fpga.el
+++ b/fpga.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/gmlarumbe/fpga
 ;; Version: 0.1.0
 ;; Keywords: tools
-;; Package-Requires: ((emacs "29.1") (company "0.9.13"))
+;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`company` was previously required to handle the limitation of gathering completions from multiple backends/functions with `completion-at-point`:

- The default for `comint` is to set `completion-at-point-functions` to `comint-dynamic-complete-functions`
- In turn, `comint-dynamic-complete-functions` has the default value `'(comint-c-a-p-replace-by-expanded-history comint-filename-completion)`. These functions work as if they were `completion-at-point-functions` themselves, returning completions if found and returning nil and checking next function if not. The recommended approach is to add a new capf function to `comint-dynamic-complete-functions`.
- If completion for both, files and commands, is set with two different functions, results found by one could mask the results found by the other. For example:
    - Consider current shell $PWD is /home/user
    - Type "r"
    - Try completions:
        - First function is called: `comint-filename-completion`
           - Finds a directory named "repos" and returns it as a completion candidate
        - Second function `fpga-*-capf` is not called since previous one was already successful
           - Commands like "run" or "remove" will be missed   
        - In this case commands are masked by files. Placing commands function before the files one in the hook would also have a masking effect. 

The PR implements a single capf function that handles both files and commands.

It also adds a customizable variable: `fpga-utils-shell-file-completion`, if file completion inside capf is not desired. This could be the case if using `company-files` backend with the following snippet:
```elisp
(setq-local comint-dynamic-complete-functions '(fpga-xilinx-vivado-shell-capf))
(setq-local company-backends '(company-files company-capf))
```