### PR TITLE
optional renamimg of compilation buffer

### DIFF
--- a/fpga-utils.el
+++ b/fpga-utils.el
@@ -150,7 +150,7 @@ BUF-NAME determines the name of the compilation buffer."
   `(define-compilation-mode ,name ,desc ,docstring
      (setq-local compilation-error-regexp-alist (mapcar #'car ,compile-re))
      (setq-local compilation-error-regexp-alist-alist ,compile-re)
-     (when ,buf (rename-buffer ,buf-name))
+     (when ,buf-name (rename-buffer ,buf-name))
      (setq truncate-lines t)
      (goto-char (point-max))))
 
@@ -231,7 +231,7 @@ FONT-LOCK-KWDS determine syntax highlighting for the shell mode."
          :global nil
          (setq-local compilation-error-regexp-alist (mapcar #'car ,compile-re))
          (setq-local compilation-error-regexp-alist-alist ,compile-re)
-         (when ,buf (rename-buffer ,buf-name))
+         (when ,buf (rename-buffer ,buf))
          (setq truncate-lines t)
          (goto-char (point-max))
          (setq-local comint-dynamic-complete-functions '(,capf-fn)))

--- a/fpga-utils.el
+++ b/fpga-utils.el
@@ -166,7 +166,7 @@ COMP-MODE is the name of the compilation derived mode created by macro
   (declare (indent 1) (debug 1))
   `(defun ,name (command)
      ,docstring
-     (when (get-buffer ,buf)
+     (when (and ,buf (get-buffer ,buf))
        (if (y-or-n-p (format "Buffer %s is in use, kill its process and start new compilation?" ,buf))
            (kill-buffer ,buf)
          (user-error "Aborted")))

--- a/fpga-utils.el
+++ b/fpga-utils.el
@@ -166,7 +166,7 @@ COMP-MODE is the name of the compilation derived mode created by macro
   (declare (indent 1) (debug 1))
   `(defun ,name (command)
      ,docstring
-     (when (get-buffer ,buf)
+     (when (get-buffer (or ,buf "*vivado*"))
        (if (y-or-n-p (format "Buffer %s is in use, kill its process and start new compilation?" ,buf))
            (kill-buffer ,buf)
          (user-error "Aborted")))

--- a/fpga-utils.el
+++ b/fpga-utils.el
@@ -150,7 +150,7 @@ BUF-NAME determines the name of the compilation buffer."
   `(define-compilation-mode ,name ,desc ,docstring
      (setq-local compilation-error-regexp-alist (mapcar #'car ,compile-re))
      (setq-local compilation-error-regexp-alist-alist ,compile-re)
-     (rename-buffer ,buf-name)
+     (when ,buf (rename-buffer ,buf-name))
      (setq truncate-lines t)
      (goto-char (point-max))))
 
@@ -231,7 +231,7 @@ FONT-LOCK-KWDS determine syntax highlighting for the shell mode."
          :global nil
          (setq-local compilation-error-regexp-alist (mapcar #'car ,compile-re))
          (setq-local compilation-error-regexp-alist-alist ,compile-re)
-         (rename-buffer ,buf)
+         (when ,buf (rename-buffer ,buf-name))
          (setq truncate-lines t)
          (goto-char (point-max))
          (setq-local comint-dynamic-complete-functions '(,capf-fn)))

--- a/fpga-utils.el
+++ b/fpga-utils.el
@@ -166,7 +166,7 @@ COMP-MODE is the name of the compilation derived mode created by macro
   (declare (indent 1) (debug 1))
   `(defun ,name (command)
      ,docstring
-     (when (get-buffer (or ,buf "*vivado*"))
+     (when (get-buffer ,buf)
        (if (y-or-n-p (format "Buffer %s is in use, kill its process and start new compilation?" ,buf))
            (kill-buffer ,buf)
          (user-error "Aborted")))


### PR DESCRIPTION
When using hdlmake and helm-make, for example, compilation buffer name is automatically set. Mandatory renaming breaks this functionality.

With this change, using a nil value as fpga-xilinx-vivado-buf would be enough.